### PR TITLE
Fix image downloading

### DIFF
--- a/job-orchestrator/tasks.py
+++ b/job-orchestrator/tasks.py
@@ -2,7 +2,6 @@ import os
 from celery import Celery
 import requests
 
-import urllib.request
 import numpy as np
 import cv2
 
@@ -65,8 +64,8 @@ def _mint_nft(recipient, payer, token_uri, price):
   return requests.post(NFT_SERVICE_MINT_TOKEN_URL, json=payload)
 
 def _download_image(url):
-  resp = urllib.request.urlopen(url)
-  image = np.asarray(bytearray(resp.read()), dtype="uint8")
+  resp = requests.get(url, stream=True).content
+  image = np.asarray(bytearray(resp), dtype="uint8")
   image = cv2.imdecode(image, cv2.IMREAD_COLOR)
 
   return image


### PR DESCRIPTION
The package we were using previously would throw 403 Forbidden
```
Traceback (most recent call last):
  File "demo.py", line 20, in <module>
    resp = urllib.request.urlopen(URL)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/urllib/request.py", line 222, in urlopen
    return opener.open(url, data, timeout)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/urllib/request.py", line 531, in open
    response = meth(req, response)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/urllib/request.py", line 640, in http_response
    response = self.parent.error(
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/urllib/request.py", line 569, in error
    return self._call_chain(*args)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/urllib/request.py", line 502, in _call_chain
    result = func(*args)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/urllib/request.py", line 649, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 403: Forbidden
```

The reason this happens is because some websites don't like programs to download their data, so one way around it is to set the request agent to some browser, and trick them.

The other package I have changed to works out of the box, so I guess it does it automatically. (Will check if problems persist, or just do it manually).