### PR TITLE
Tasks retry mechanisms

### DIFF
--- a/job-orchestrator/tasks.py
+++ b/job-orchestrator/tasks.py
@@ -38,21 +38,21 @@ def create_token(transformer, transformation_name, recipient,
 
   return status
 
-@app.task
+@app.task(autoretry_for=(Exception,), retry_kwargs={"max_retries": 3, "countdown": 5})
 def cartoonify(transformation_name, recipient, payer, price, image_url, image_name):
   cartoonifier = transformers.Cartoonifier()
   status = create_token(cartoonifier, transformation_name, recipient, payer, price, image_url, image_name)
 
   return status
 
-@app.task
+@app.task(autoretry_for=(Exception,), retry_kwargs={"max_retries": 3, "countdown": 5})
 def ascii(transformation_name, recipient, payer, price, image_url, image_name):
   ascii = transformers.ASCIIArt()
   status = create_token(ascii, transformation_name, recipient, payer, price, image_url, image_name)
 
   return status
 
-@app.task
+@app.task(autoretry_for=(Exception,), retry_kwargs={"max_retries": 3, "countdown": 5})
 def sketch(transformation_name, recipient, payer, price, image_url, image_name):
   sketch = transformers.SketchArt()
   status = create_token(sketch, transformation_name, recipient, payer, price, image_url, image_name)


### PR DESCRIPTION
The goal is to have fault tolerant tasks.
The easiest way to do this is to set retry mechanisms on celery side, the tasks will retry 3 times.
After that we should catch the exception and maybe send a notification to slack or something.

So, for the first version (not the best approach):
1. In the first 3 tries, we don't care what failed, just retry it
2. If it fails 3 times, send us an alert on slack to check manually

What do you think about this? @pyromaniackeca 
Also, what approach would you go for with defining our own exceptions?

TODO:
1. Define our own exceptions
2. Alerting
3. Logging
4. Figure out how to test retries (or whether to test it, since it's a tool feature -  maybe only in end to end tests?)