### PR TITLE
Celery alerts

### DIFF
--- a/job-orchestrator/.env.example
+++ b/job-orchestrator/.env.example
@@ -3,3 +3,5 @@ BROKER_URL = "redis://redis:6379/0"
 PINATA_JWT = "jwt"
 
 NFT_SERVICE_MINT_TOKEN_URL = "http://nft-service:7000/mint_nft"
+
+SLACK_WEBHOOK_URL = ""

--- a/job-orchestrator/requirements.txt
+++ b/job-orchestrator/requirements.txt
@@ -1,10 +1,11 @@
-amqp==5.0.6
+amqp==2.6.1
 appnope==0.1.2
 asgiref==3.4.1
 attrs==21.2.0
 backcall==0.2.0
 billiard==3.6.4.0
-celery==5.1.2
+celery==4.4.7
+celery-slack==0.4.1
 certifi==2021.5.30
 charset-normalizer==2.0.4
 click==7.1.2
@@ -13,6 +14,7 @@ click-plugins==1.1.1
 click-repl==0.2.0
 colour==0.1.5
 decorator==5.0.9
+ephem==3.7.7.1
 greenlet==1.1.1
 h11==0.12.0
 idna==3.2
@@ -20,7 +22,7 @@ iniconfig==1.1.1
 ipython==7.26.0
 ipython-genutils==0.2.0
 jedi==0.18.0
-kombu==5.1.0
+kombu==4.6.11
 logassert==6
 matplotlib-inline==0.1.2
 numpy==1.21.1
@@ -49,5 +51,5 @@ toml==0.10.2
 traitlets==5.0.5
 typing-extensions==3.10.0.0
 urllib3==1.26.6
-vine==5.0.0
+vine==1.3.0
 wcwidth==0.2.5

--- a/job-orchestrator/tasks.py
+++ b/job-orchestrator/tasks.py
@@ -1,6 +1,8 @@
 import os
-from celery import Celery
 import requests
+
+from celery import Celery
+from celery_slack import Slackify
 
 import numpy as np
 import cv2
@@ -9,13 +11,20 @@ from pinata import PinataClient
 import transformers
 import working_directory
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 POSTGRES_URL = os.getenv("POSTGRES_CONNECTION_URL")
 BROKER_URL = os.getenv("BROKER_URL")
 PINATA_JWT = os.getenv("PINATA_JWT")
+SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL")
 
 NFT_SERVICE_MINT_TOKEN_URL = os.getenv("NFT_SERVICE_MINT_TOKEN_URL")
 
 app = Celery("tasks", backend=POSTGRES_URL, broker=BROKER_URL)
+print(SLACK_WEBHOOK_URL)
+Slackify(app, SLACK_WEBHOOK_URL)
 
 def create_token(transformer, transformation_name, recipient,
                  payer, price, image_url, image_name):


### PR DESCRIPTION
Sets up celery alerts to slack.
Based on: https://celery-slack.readthedocs.io/en/latest/index.html
Good explanation on how to integrate alerts: https://flynn.gg/blog/integrating-celery-with-slack/

This package has a few problems:
1. Not maintained anymore (last commit 2 years ago)
2. Requires lower versions of some packages
3. Does not have alerts for retries

We should create our own minimalistic package for alerting. 
But will go with this one for now, since it's easy to integrate.

<img width="294" alt="Screenshot 2021-09-12 at 10 49 36" src="https://user-images.githubusercontent.com/10870130/132981630-ddae18e5-bae6-41b8-b76d-f04615cbcac3.png">
<img width="703" alt="Screenshot 2021-09-12 at 10 49 46" src="https://user-images.githubusercontent.com/10870130/132981634-db37c08d-5cb1-431d-9e52-ad469ff0966f.png">
<img width="692" alt="Screenshot 2021-09-12 at 10 49 54" src="https://user-images.githubusercontent.com/10870130/132981644-cae3b472-4fc2-4af8-bf91-958f456f76a4.png">
<img width="259" alt="Screenshot 2021-09-12 at 10 49 59" src="https://user-images.githubusercontent.com/10870130/132981651-da4af432-5598-493e-b277-95c9733f7549.png">
