### PR TITLE
Scope husky lint-staged run to client folder

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -61,10 +61,10 @@
     }
   },
   "lint-staged": {
-    "*.{js,ts,tsx}": [
+    "client/**/*.{js,ts,tsx}": [
       "eslint --quiet --fix"
     ],
-    "*.{json,md,html,scss}": [
+    "client/**/*.{json,md,html,scss}": [
       "prettier --write"
     ]
   },


### PR DESCRIPTION
Tested on a non client folder `.js` file where prettier wasn't automatically run.