### PR TITLE
Restrict contract interaction unless wallet is connected

### DIFF
--- a/client/src/components/GenerateScene/PayGenerateForm/PayGenerateForm.tsx
+++ b/client/src/components/GenerateScene/PayGenerateForm/PayGenerateForm.tsx
@@ -56,7 +56,7 @@ export const PayGenerateForm: React.FC<Record<string, unknown>> = () => {
 
   const handlePayGenerating = async () => {
     if (contract && selectedTransformationType) {
-      // Loading finish is triggered either on payGenerating error or tokenMintedEvent
+      // Loading finish is triggered either on payGenerating error or tokenTransferredEvent
       dispatch(createSetPayGeneratingLoadingAction(true));
       try {
         const payGeneratingResult: PayGeneratingResult = await contract.methods

--- a/client/src/components/LandingScene/LandingScene.styles.ts
+++ b/client/src/components/LandingScene/LandingScene.styles.ts
@@ -36,7 +36,17 @@ export const useStyles = makeStyles((theme) => ({
     textAlign: 'center'
   },
   ctaButtonsContainer: {
-    display: 'flex'
+    display: 'flex',
+    opacity: 0,
+    transform: 'translate(0, -2rem)',
+    transition: theme.transitions.create(['opacity', 'transform'], {
+      duration: theme.transitions.duration.short,
+      easing: theme.transitions.easing.easeOut
+    })
+  },
+  show: {
+    opacity: 1,
+    transform: 'translate(0)'
   },
   generateButton: {
     marginRight: theme.spacing(1)

--- a/client/src/components/LandingScene/LandingScene.tsx
+++ b/client/src/components/LandingScene/LandingScene.tsx
@@ -1,8 +1,15 @@
 import { Box, Button, Typography } from '@material-ui/core';
+import { useWallet } from 'contexts/WalletContext/WalletContext';
 import { useHistory } from 'react-router-dom';
 import { useStyles } from './LandingScene.styles';
 
 export const LandingScene: React.FC<Record<string, unknown>> = () => {
+  const {
+    state: { accounts }
+  } = useWallet();
+
+  const isWalletConnected = accounts[0];
+
   const history = useHistory();
 
   const handleGenerateClick = () => {
@@ -26,7 +33,7 @@ export const LandingScene: React.FC<Record<string, unknown>> = () => {
           AI NFT Art
         </Typography>
 
-        <Box className={classes.ctaButtonsContainer}>
+        <Box className={`${classes.ctaButtonsContainer} ${isWalletConnected && classes.show}`}>
           <Button
             className={classes.generateButton}
             color="primary"

--- a/client/src/components/RootView/RootView.tsx
+++ b/client/src/components/RootView/RootView.tsx
@@ -6,9 +6,16 @@ import { LandingScene } from 'components/LandingScene/LandingScene';
 import { WalletConnector } from 'components/WalletConnector/WalletConnector';
 import { useStyles } from './RootView.styles';
 import { ExploreScene } from 'components/ExploreScene/ExploreScene';
+import { useWallet } from 'contexts/WalletContext/WalletContext';
 
 export const RootView: React.FC<Record<string, unknown>> = () => {
   const classes = useStyles();
+
+  const {
+    state: { accounts }
+  } = useWallet();
+
+  const isWalletConnected = accounts[0];
 
   return (
     <Box className={classes.root}>
@@ -17,9 +24,10 @@ export const RootView: React.FC<Record<string, unknown>> = () => {
       </Box>
 
       <Switch>
+        {isWalletConnected && <Route exact path="/generate" component={GenerateScene} />}
+        {isWalletConnected && <Route exact path="/explore" component={ExploreScene} />}
+
         <Route exact path="/" component={LandingScene} />
-        <Route exact path="/generate" component={GenerateScene} />
-        <Route exact path="/explore" component={ExploreScene} />
         <Route path="" render={() => <Redirect to="/" />} />
       </Switch>
     </Box>


### PR DESCRIPTION
User is no longer presented with navigation buttons unless his wallet is connected.

He also cannot manually visit a protected route. 

There is a UX opportunity here if we preserve last visited route if navigating to landing page via protected route guard (useful for bookmarks)
