### PR TITLE
Add price to transformation info

### DIFF
--- a/client/src/components/TransformationCard/TransformationCard.tsx
+++ b/client/src/components/TransformationCard/TransformationCard.tsx
@@ -1,3 +1,4 @@
+import Web3 from 'web3';
 import { Box, Button, Typography } from '@material-ui/core';
 import { images } from 'config/imageLoader/imageLoader';
 import ReactCompareImage from 'react-compare-image';
@@ -52,9 +53,9 @@ export const TransformationCard: React.FC<TransformationCardProps> = ({ transfor
 
             <Box className={classes.transformationStat}>
               <Typography className={classes.transformationStatValue} variant="h6">
-                15
+                {Web3.utils.fromWei(transformation.price.toString())} ETH
               </Typography>
-              <Typography>Lorem start</Typography>
+              <Typography>Price</Typography>
             </Box>
           </Box>
 

--- a/client/src/components/TransformationDetailsScene/TransformationDetailsScene.tsx
+++ b/client/src/components/TransformationDetailsScene/TransformationDetailsScene.tsx
@@ -1,3 +1,4 @@
+import Web3 from 'web3';
 import {
   Box,
   Button,
@@ -75,9 +76,9 @@ export const TransformationDetailsScene: React.FC<Record<string, unknown>> = () 
 
             <Box className={classes.transformationStat}>
               <Typography className={classes.transformationStatValue} variant="h6">
-                15
+                {Web3.utils.fromWei(transformation.price.toString())} ETH
               </Typography>
-              <Typography>Lorem start</Typography>
+              <Typography>Price</Typography>
             </Box>
           </Box>
         </Box>


### PR DESCRIPTION
Transformation card
<img width="1251" alt="Screenshot 2021-10-26 at 23 20 55" src="https://user-images.githubusercontent.com/10870130/138962773-078ad4e8-d18f-4dc1-86c5-23e58349b38a.png">

Transformation detail scene
<img width="1276" alt="Screenshot 2021-10-26 at 23 20 21" src="https://user-images.githubusercontent.com/10870130/138962671-676b3de9-b25e-440c-8c17-9ea202b348d8.png">

Will test it later with real world prices.