### PR TITLE
Add basic celery config

### DIFF
--- a/job-orchestrator/celeryconfig.py
+++ b/job-orchestrator/celeryconfig.py
@@ -1,0 +1,10 @@
+import os
+
+broker_url = os.getenv("BROKER_URL")
+result_backend = os.getenv("POSTGRES_CONNECTION_URL")
+
+task_serializer = 'json'
+result_serializer = 'json'
+accept_content = ['json']
+timezone = 'Europe/Oslo'
+enable_utc = True

--- a/job-orchestrator/tasks.py
+++ b/job-orchestrator/tasks.py
@@ -12,13 +12,11 @@ from transformers import model_paths
 import working_directory
 import logger
 
-POSTGRES_URL = os.getenv("POSTGRES_CONNECTION_URL")
-BROKER_URL = os.getenv("BROKER_URL")
 PINATA_JWT = os.getenv("PINATA_JWT")
-
 NFT_SERVICE_MINT_TOKEN_URL = os.getenv("NFT_SERVICE_MINT_TOKEN_URL")
 
-app = Celery("tasks", backend=POSTGRES_URL, broker=BROKER_URL)
+app = Celery("tasks")
+app.config_from_object("celeryconfig")
 
 def create_token(transformer, transformation_name, transformation_number,
                  payer, image_url, image_name):


### PR DESCRIPTION
Adding queues atm is not doable.
Queues are good for differentiating tasks with different requirements, but workers can't set concurrency per queue.
So if different concurrency is needed for a queue, another worker is needed.
Workers spawn child processes which are our jobs.